### PR TITLE
Fix code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/src/helpers/linkUtils.js
+++ b/src/helpers/linkUtils.js
@@ -13,7 +13,7 @@ function extractLinks(content) {
           .slice(2, -2)
           .split("|")[0]
           .replace(/.(md|markdown)\s?$/i, "")
-          .replace("\\", "")
+          .replace(/\\/g, "")
           .trim()
           .split("#")[0]
     ),
@@ -23,7 +23,7 @@ function extractLinks(content) {
           .slice(6, -1)
           .split("|")[0]
           .replace(/.(md|markdown)\s?$/i, "")
-          .replace("\\", "")
+          .replace(/\\/g, "")
           .trim()
           .split("#")[0]
     ),


### PR DESCRIPTION
Fixes [https://github.com/WonderingGodling/My-Mind-Space/security/code-scanning/2](https://github.com/WonderingGodling/My-Mind-Space/security/code-scanning/2)

To fix the problem, we need to ensure that all occurrences of backslashes in the `link` string are replaced, not just the first one. This can be achieved by using a regular expression with the global (`g`) flag. This change will ensure that every backslash in the string is replaced, thus preventing any potential issues related to incomplete escaping.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
