### PR TITLE
Fix code scanning alert no. 4: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "markdown-it-plantuml": "^1.4.1",
         "markdown-it-task-checkbox": "^1.0.6",
         "npm-run-all": "^4.1.5",
-        "rimraf": "^4.4.1"
+        "rimraf": "^4.4.1",
+        "sanitize-html": "^2.13.1"
     }
 }

--- a/src/site/_includes/components/searchScript.njk
+++ b/src/site/_includes/components/searchScript.njk
@@ -1,5 +1,6 @@
 <script src="https://cdn.jsdelivr.net/npm/flexsearch@0.7.21/dist/flexsearch.bundle.js"></script>
 <script>
+    const sanitizeHtml = require('sanitize-html');
     document.addEventListener('DOMContentLoaded', init, false);
     document.addEventListener('DOMContentLoaded', setCorrectShortcut, false);
 
@@ -324,7 +325,10 @@
 
     function truncate(str, size) {
         //first, remove HTML
-        str = str.replaceAll(/<[^>]*>/g, '');
+        str = sanitizeHtml(str, {
+            allowedTags: [],
+            allowedAttributes: {}
+        });
         if (str.length < size) 
             return str;
         return str.substring(0, size - 3) + '...';


### PR DESCRIPTION
Fixes [https://github.com/WonderingGodling/My-Mind-Space/security/code-scanning/4](https://github.com/WonderingGodling/My-Mind-Space/security/code-scanning/4)

To fix the problem, we should use a well-tested sanitization library that can handle the complexities of HTML and script tag removal. The `sanitize-html` library is a popular choice for this purpose. It provides robust sanitization and is designed to handle various edge cases that simple regular expressions might miss.

**Steps to fix:**
1. Install the `sanitize-html` library.
2. Replace the existing regular expression-based sanitization with a call to `sanitize-html`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
