### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/WonderingGodling/My-Mind-Space/security/code-scanning/7](https://github.com/WonderingGodling/My-Mind-Space/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly set the permissions to `contents: read`, which is sufficient for the workflow's operations (e.g., checking out the repository and running tests). This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
