### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-grunt.yml
+++ b/.github/workflows/npm-grunt.yml
@@ -1,4 +1,6 @@
 name: NodeJS with Grunt
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/WonderingGodling/My-Mind-Space/security/code-scanning/8](https://github.com/WonderingGodling/My-Mind-Space/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Since the workflow only checks out the repository and performs a build, it likely only needs `contents: read` permission. This change will ensure that the workflow does not have unnecessary write permissions.

The `permissions` block will be added immediately after the `name` field in the workflow file to apply the permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
