### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -3,6 +3,9 @@
 
 name: Node.js Package
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [created]


### PR DESCRIPTION
Potential fix for [https://github.com/WonderingGodling/My-Mind-Space/security/code-scanning/9](https://github.com/WonderingGodling/My-Mind-Space/security/code-scanning/9)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the default permissions for all jobs. This will ensure that the `build` job, which does not require write permissions, is limited to `contents: read`. The `publish-gpr` job already has its own `permissions` block, so it will not be affected by the root-level permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
