### PR TITLE
Potential fix for code scanning alert no. 19: Incomplete multi-character sanitization

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -450,6 +450,15 @@ module.exports = function(eleventyConfig) {
 
   // Shared helper to transform callout blockquotes - used by both callout-block transform and canvas-markdown
   const calloutMeta = /\[!([\w-]*)\|?(\s?.*)\](\+|\-){0,1}(\s?.*)/;
+  function escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
   function transformCalloutBlockquotes(blockquotes) {
     for (const blockquote of blockquotes) {
       // Process nested blockquotes first
@@ -471,11 +480,12 @@ module.exports = function(eleventyConfig) {
         function(metaInfoMatch, callout, metaData, collapse, title) {
           isCollapsable = Boolean(collapse);
           isCollapsed = collapse === "-";
-          const titleText = title.replace(/(<\/{0,1}\w+>)/, "")
+          const rawTitleText = title
             ? title
             : `${callout.charAt(0).toUpperCase()}${callout
               .substring(1)
               .toLowerCase()}`;
+          const titleText = escapeHtml(rawTitleText);
           const fold = isCollapsable
             ? `<div class="callout-fold"><i icon-name="chevron-down"></i></div>`
             : ``;


### PR DESCRIPTION
Potential fix for [https://github.com/WonderingGodling/My-Mind-Space/security/code-scanning/19](https://github.com/WonderingGodling/My-Mind-Space/security/code-scanning/19)

Best fix: stop trying to strip HTML tags with a fragile regex and instead HTML-escape the title before interpolation into `innerHTML`. Escaping (`&`, `<`, `>`, `"`, `'`) prevents tag/script execution regardless of malformed or nested input, and preserves existing functionality (displaying text title content).

Concretely in `.eleventy.js`:
- Add a small helper function (e.g., `escapeHtml`) in the same shown region before `transformCalloutBlockquotes`.
- In line 474 logic, replace the regex-based check/sanitization with:
  - compute `rawTitleText` as either `title` or fallback callout name (same existing behavior),
  - then `const titleText = escapeHtml(rawTitleText);`
- Keep all other logic unchanged.

No new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
