### PR TITLE
Potential fix for code scanning alert no. 18: Incomplete string escaping or encoding

### DIFF
--- a/src/helpers/linkUtils.js
+++ b/src/helpers/linkUtils.js
@@ -34,7 +34,7 @@ function extractLinks(content) {
           .slice(2, -2)
           .split("|")[0]
           .replace(/\.(md|markdown)\s?$/i, "")
-          .replace("\\", "")
+          .replace(/\\/g, "")
           .trim()
           .split("#")[0]
     ),
@@ -45,7 +45,7 @@ function extractLinks(content) {
           .split("|")[0]
           // Don't strip .canvas - canvas URLs actually include it
           .replace(/\.(md|markdown)\s?$/i, "")
-          .replace("\\", "")
+          .replace(/\\/g, "")
           .trim()
           .split("#")[0]
     ),


### PR DESCRIPTION
Potential fix for [https://github.com/WonderingGodling/My-Mind-Space/security/code-scanning/18](https://github.com/WonderingGodling/My-Mind-Space/security/code-scanning/18)

Use a global regular expression to replace all backslashes, not just the first one.

Best fix in this file: change the `.replace("\\", "")` calls in `extractLinks` to `.replace(/\\/g, "")` so every backslash is removed consistently. This preserves existing behavior intent (strip backslashes) while fixing incompleteness. No new imports or helper methods are needed.

Edits needed in `src/helpers/linkUtils.js`:
- In the wiki-link mapping chain, replace `.replace("\\", "")` with `.replace(/\\/g, "")`.
- In the internal-link mapping chain (the CodeQL-highlighted area), replace `.replace("\\", "")` with `.replace(/\\/g, "")`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
