### PR TITLE
Potential fix for code scanning alert no. 16: Incomplete multi-character sanitization

### DIFF
--- a/src/site/_includes/components/searchScript.njk
+++ b/src/site/_includes/components/searchScript.njk
@@ -69,6 +69,13 @@
 
     // ===== Highlighting Utilities =====
 
+    function stripHtmlToText(input) {
+        if (!input) return '';
+        const container = document.createElement('div');
+        container.innerHTML = input;
+        return container.textContent || container.innerText || '';
+    }
+
     function tokenizeSearchTerms(query) {
         const terms = [];
         const regex = /"([^"]+)"|(\S+)/g;
@@ -95,7 +102,7 @@
 
     function getContextualExcerpt(content, terms, maxLength = 150) {
         if (!content) return '';
-        const plainText = content.replace(/<[^>]*>/g, '');
+        const plainText = stripHtmlToText(content);
 
         if (!terms || terms.length === 0) {
             return truncateText(plainText, maxLength);
@@ -126,7 +133,7 @@
 
     function truncateText(str, size) {
         if (!str) return '';
-        str = str.replace(/<[^>]*>/g, '');
+        str = stripHtmlToText(str);
         if (str.length <= size) return str;
         return str.substring(0, size - 3) + '...';
     }


### PR DESCRIPTION
Potential fix for [https://github.com/WonderingGodling/My-Mind-Space/security/code-scanning/16](https://github.com/WonderingGodling/My-Mind-Space/security/code-scanning/16)

Use DOM-based parsing to extract text instead of regex tag stripping.  
Best fix (without changing intended functionality): replace both regex removals with a helper that decodes/removes HTML safely by parsing into a detached DOM node and reading `textContent`. This avoids incomplete multi-character sanitization and handles malformed markup more safely than regex.

In `src/site/_includes/components/searchScript.njk`:
- Add a new helper function near the highlighting utilities, e.g. `stripHtmlToText(input)`.
- Update:
  - line 98 equivalent: `const plainText = stripHtmlToText(content);`
  - line 129 equivalent: `str = stripHtmlToText(str);`

No new imports/dependencies are needed since this runs in browser context and can use `document.createElement`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
