### PR TITLE
Potential fix for code scanning alert no. 14: DOM text reinterpreted as HTML

### DIFF
--- a/src/site/_includes/components/searchScript.njk
+++ b/src/site/_includes/components/searchScript.njk
@@ -365,6 +365,15 @@
     window.searchTerms = [];
     window.currentPreviewIndex = -1;
 
+    function escapeHtml(str) {
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
     async function search() {
         const searchQuery = field.value.trim();
         const searchLayout = document.getElementById('search-layout');
@@ -387,6 +396,7 @@
 
         if (!results.length) {
             if (searchLayout) searchLayout.classList.add('no-preview');
+            const safeSearchQuery = escapeHtml(searchQuery);
             resultsDiv.innerHTML = `
                 <div class="no-results">
                     <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -394,7 +404,7 @@
                         <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
                         <line x1="8" y1="11" x2="14" y2="11"></line>
                     </svg>
-                    <p>{{ meta.uiStrings.searchNoResults }} "${searchQuery}"</p>
+                    <p>{{ meta.uiStrings.searchNoResults }} "${safeSearchQuery}"</p>
                 </div>
             `;
             return;


### PR DESCRIPTION
Potential fix for [https://github.com/WonderingGodling/My-Mind-Space/security/code-scanning/14](https://github.com/WonderingGodling/My-Mind-Space/security/code-scanning/14)

General fix: never place untrusted text directly into HTML strings that are assigned to `innerHTML`. Either:
1) build DOM nodes and set untrusted content via `textContent`, or  
2) HTML-escape untrusted data before interpolation.

Best minimal fix without changing functionality in this snippet: **escape `searchQuery` before interpolating it into the no-results HTML**.

In `src/site/_includes/components/searchScript.njk`:
- Add a small helper function in the script to escape HTML metacharacters (`& < > " '`).
- In the `if (!results.length)` block, compute `const safeSearchQuery = escapeHtml(searchQuery);`.
- Replace `"${searchQuery}"` in the template with `"${safeSearchQuery}"`.

This preserves current rendering and layout while preventing XSS from user-provided query text.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
